### PR TITLE
fix: Add Metadata field to meta and ItemOptions structs, update related functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [Unreleased] - 2025-05-21
+
+### Added
+- Introduced a `Metadata` field of type `json.RawMessage` to both `meta` and `ItemOptions` structs in [`meta.go`](meta.go) and [`options.go`](options.go), allowing storage of arbitrary custom metadata for cache items.
+- Added new tests in [`meta_test.go`](meta_test.go) to verify correct handling and round-trip preservation of the `Metadata` field, including cases with non-empty and nil metadata.
+
+### Changed
+- Updated `newMeta` and `metaToOptions` functions in [`meta.go`](meta.go) to support copying the new `Metadata` field between `meta` and `ItemOptions`.
+- Updated imports in [`options.go`](options.go) to include `encoding/json` for the new metadata functionality.

--- a/meta.go
+++ b/meta.go
@@ -54,14 +54,16 @@ func newMeta(key string, options *ItemOptions, defaultTTL time.Duration) *meta {
 		Name:      options.Name,
 		TTL:       ttl,
 		Fields:    options.Fields,
+		Metadata:  options.Metadata,
 	}
 }
 
 func metaToOptions(meta *meta) *ItemOptions {
 	return &ItemOptions{
-		Name:   meta.Name,
-		TTL:    meta.TTL,
-		Fields: meta.Fields,
+		Name:     meta.Name,
+		TTL:      meta.TTL,
+		Fields:   meta.Fields,
+		Metadata: meta.Metadata,
 	}
 }
 
@@ -81,6 +83,9 @@ type meta struct {
 
 	// Fields is a map of any other metadata fields.
 	Fields Values `json:"f,omitempty"`
+
+	// Custom metadata of any custom type.
+	Metadata json.RawMessage `json:"m,omitempty"`
 }
 
 func (m *meta) isExpired() bool {

--- a/meta_test.go
+++ b/meta_test.go
@@ -1,0 +1,49 @@
+package filecache
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMeta_MetadataField_RoundTrip(t *testing.T) {
+	// Sample metadata as arbitrary JSON
+	sampleMetadata := json.RawMessage(`{"foo":"bar","num":42,"arr":[1,2,3]}`)
+
+	opts := &ItemOptions{
+		Name:     "test-item",
+		TTL:      2 * time.Hour,
+		Fields:   Values{"a": "b"},
+		Metadata: sampleMetadata,
+	}
+
+	// Convert ItemOptions to meta
+	m := newMeta("test-key", opts, 0)
+	assert.Equal(t, sampleMetadata, m.Metadata, "Metadata should be copied to meta")
+
+	// Convert meta back to ItemOptions
+	opts2 := metaToOptions(m)
+	assert.Equal(t, sampleMetadata, opts2.Metadata, "Metadata should be preserved in round-trip")
+
+	// Check other fields are also preserved
+	assert.Equal(t, opts.Name, opts2.Name)
+	assert.Equal(t, opts.TTL, opts2.TTL)
+	assert.Equal(t, opts.Fields, opts2.Fields)
+}
+
+func TestMeta_MetadataField_Empty(t *testing.T) {
+	opts := &ItemOptions{
+		Name:     "empty-meta",
+		TTL:      0,
+		Fields:   nil,
+		Metadata: nil,
+	}
+
+	m := newMeta("empty-key", opts, 0)
+	assert.Nil(t, m.Metadata, "Metadata should be nil if not set")
+
+	opts2 := metaToOptions(m)
+	assert.Nil(t, opts2.Metadata, "Metadata should remain nil after round-trip")
+}

--- a/options.go
+++ b/options.go
@@ -1,6 +1,9 @@
 package filecache
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // InstanceOptions are a cache instance options.
 type InstanceOptions struct {
@@ -47,4 +50,7 @@ type ItemOptions struct {
 
 	// Fields is a map of any other metadata fields.
 	Fields Values
+
+	// Custom metadata of any custom type.
+	Metadata json.RawMessage
 }


### PR DESCRIPTION
### Added
- Introduced a `Metadata` field of type `json.RawMessage` to both `meta` and `ItemOptions` structs in [`meta.go`](meta.go) and [`options.go`](options.go), allowing storage of arbitrary custom metadata for cache items.
- Added new tests in [`meta_test.go`](meta_test.go) to verify correct handling and round-trip preservation of the `Metadata` field, including cases with non-empty and nil metadata.

### Changed
- Updated `newMeta` and `metaToOptions` functions in [`meta.go`](meta.go) to support copying the new `Metadata` field between `meta` and `ItemOptions`.
- Updated imports in [`options.go`](options.go) to include `encoding/json` for the new metadata functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for storing and retrieving custom metadata as raw JSON in cache items.
- **Tests**
  - Introduced new tests to ensure correct handling and preservation of custom metadata in cache operations.
- **Documentation**
  - Updated documentation to reflect the addition of the custom metadata feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->